### PR TITLE
HF-53: 회원가입 api 수정 - useForm을 통한 request body 전달

### DIFF
--- a/src/api/login/loginResponseHandler.js
+++ b/src/api/login/loginResponseHandler.js
@@ -16,15 +16,15 @@ const loginResponseHandler = async (dispatch, code) => {
         console.log(state);
         return {
             statusCode: response.status,
-            // message
+            message : response.data.message
         }
 
     } catch (error) {
         console.log('error',error);
         return {
-            statusCode: error.response.status
-            // message
-        };
+            statusCode: error.response.status,
+            message : error.response.data.message
+        }
     }
 }
 

--- a/src/api/signup/signupHandler.js
+++ b/src/api/signup/signupHandler.js
@@ -1,0 +1,23 @@
+import apiClient from "../axios"
+
+const signupHandler = async (data) => {
+    console.log('data in singupHandler', data);
+    try{
+        const response = await apiClient.post('/auth/signup',{
+            data
+        })
+
+        console.log(response)
+        return {
+            statusCode : response.status
+        }
+    }
+    catch(error){
+        console.error(error)
+        return {
+            statusCode : error.response.status
+        }
+    }
+}
+
+export default signupHandler

--- a/src/components/signup/step02/InformationForm.js
+++ b/src/components/signup/step02/InformationForm.js
@@ -5,6 +5,8 @@ import Input from "@/components/common/Input";
 import InputLabel from "../InputLabel";
 import Button from "@/components/common/Button";
 import { useForm } from "react-hook-form";
+import signupHandler from "@/api/signup/signupHandler";
+import { useNavigate } from "react-router-dom";
 
 const InformationForm = ({ setStepNum }) => {
 
@@ -12,16 +14,28 @@ const InformationForm = ({ setStepNum }) => {
       register,
       handleSubmit,
       formState: {errors, isSubmitted, isValid}
-    } = useForm({ mode: "onSubmit"});
+    } = useForm({ mode: "onSubmit"} )
+    ;
+    const navigate = useNavigate();
 
   return (
     <Wrapper 
       noValidate
-      onSubmit={handleSubmit(data => {
-        console.log('data',data)
-        console.log(data.name);
-        console.log(data.nickname);
-        console.log(data.phoneNumber1 + '-' + data.phoneNumber2 + '-' + data.phoneNumber3)
+      onSubmit={handleSubmit(async (data) => {
+        const result = await signupHandler({
+          name : data.name,
+          nickname : data.nickname,
+          email : "test@naver.com",
+          emailAgree : data.emailAgree,
+          phoneNumber : data.phoneNumber1 + '-' + data.phoneNumber2 + '-' + data.phoneNumber3
+        });
+
+        if(result.statusCode === 200){
+          setStepNum(prev => prev+1)
+        }
+        else{
+          navigate('/error')
+        }
       })}
     >
       <FormContainer>


### PR DESCRIPTION
## 개요
react-hook-form 패키지 적용에 따른 회원가입 api 수정

## 구현
react-hook-form의 `handleSubmit` 함수를 통해 인자인 `data`로 전달
```js
...
<Wrapper 
      noValidate
      onSubmit={handleSubmit(async (data) => {
        const result = await signupHandler({
          name : data.name,
          nickname : data.nickname,
          email : "test@naver.com",
          emailAgree : data.emailAgree,
          phoneNumber : data.phoneNumber1 + '-' + data.phoneNumber2 + '-' + data.phoneNumber3
        });
...
```

## 기타
- 아직 회원가입 api 구현 및 로그인 api에서 unauthorized 오류가 계속 발생하여 회의 떄 다 같이 테스트해봐야 할 것 같습니다.